### PR TITLE
Unmanaged service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class radvd (
   $interfaces = {},
   $enable     = true,
   $start      = true,
+  $managesvc  = true,
   $conffile   = '/etc/radvd.conf',
 ) {
   class{'radvd::install': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,9 @@
 class radvd (
-  $version = 'present',
+  $version    = 'present',
   $interfaces = {},
-  $enable = true,
-  $start = true,
-  $conffile = '/etc/radvd.conf',
+  $enable     = true,
+  $start      = true,
+  $conffile   = '/etc/radvd.conf',
 ) {
   class{'radvd::install': }
   class{'radvd::config': }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,5 +1,9 @@
 class radvd::service {
-  $ensure = $radvd::start ? {true => running, default => stopped}
+  if $radvd::managesvc {
+    $ensure = $radvd::start
+  } else {
+    $ensure = undef
+  }
 
   service{'radvd':
     ensure => $ensure,


### PR DESCRIPTION
For networks with HA gateways/routers, it's not ideal to have many
radvd running concurrently in the same network segment. To support
those environments, make it possible for the radvd service be managed
by external tools.
