### PR TITLE
Validate radvd.conf before deploying/updating it.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,9 @@
 class radvd::config {
   concat {$radvd::conffile:
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    owner        => 'root',
+    group        => 'root',
+    mode         => '0644',
+    validate_cmd => '/usr/sbin/radvd --configtest --config %',
   }
   concat::fragment { '01-puppet-header':
     target  => $radvd::conffile,


### PR DESCRIPTION
Ensures sane a config is deployed before signaling the service.

Signed-off-by: Simon Deziel <simon@sdeziel.info>