### PR TITLE
add support for AdvRASrcAddress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Or
           'AdvAutonomous' => 'on',
         },
       },
+      rasourceaddresses => [
+        'FE80::cafe:1',
+      ],
       rdnss => {
         '2001:0DB8:2342:cafe::1' => {
           'AdvRDNSSLifetime' => 30,

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -1,6 +1,7 @@
 define radvd::interface (
   $options={},
   $prefixes={},
+  $rasourceaddresses=[],
   $rdnss={},
   $dnssl={},
   $routes={},

--- a/templates/radvd.conf-interface.erb
+++ b/templates/radvd.conf-interface.erb
@@ -13,6 +13,14 @@ interface <%= @name %>
   };
 
   <%- end -%>
+  <%- if @rasourceaddresses and not @rasourceaddresses.empty? -%>
+  AdvRASrcAddress {
+    <%- @rasourceaddresses.sort.each do |rasourceaddress| -%>
+    <%= rasourceaddress %>;
+    <%- end -%>
+  };
+
+  <%- end -%>
   <%- @rdnss.sort.each do |dns,popts| -%>
   RDNSS <%= dns %>
   {

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -20,6 +20,9 @@ node default {
         'AdvAutonomous' => 'on',
       },
     },
+    rasourceaddresses => [
+      'FE80::cafe:1',
+    ],
     rdnss    => {
       '2001:0DB8:2342:cafe::1' => {
         'AdvRDNSSLifetime' => 30,


### PR DESCRIPTION
This is required if another address than the first link-local address should be used for router advertisements, e.g. when virtual service IPs are used.